### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 GemForge-mcp is a professional Gemini API integration for Claude and MCP-compatible hosts with intelligent model selection and advanced file handling capabilities.
 
+<a href="https://glama.ai/mcp/servers/@PV-Bhat/GemForge-MCP">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@PV-Bhat/GemForge-MCP/badge" alt="GemForge-Gemini-Tools-MCP MCP server" />
+</a>
+
 ## Overview
 
 GemForge-mcp provides a Model Context Protocol (MCP) server that offers specialized tools for interacting with Google's Gemini AI models. It features intelligent model selection based on task type and content, advanced file handling, and optimized prompts for different use cases.


### PR DESCRIPTION
This PR adds a badge for the [GemForge-Gemini-Tools-MCP](https://glama.ai/mcp/servers/@PV-Bhat/GemForge-MCP) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@PV-Bhat/GemForge-MCP">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@PV-Bhat/GemForge-MCP/badge" alt="GemForge-Gemini-Tools-MCP MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.